### PR TITLE
Keyboard interrupt exception  

### DIFF
--- a/src/pieces/commands/cli_loop.py
+++ b/src/pieces/commands/cli_loop.py
@@ -92,6 +92,9 @@ def loop(**kwargs):
                 commands.append("exit")
                 most_similar_command = PiecesArgparser.find_most_similar_command(commands, user_input)
                 print(f"Did you mean {most_similar_command}")
+        except KeyboardInterrupt:
+            print("\nKeyboardInterrupt caught. Returning to the main loop.")
+            continue
         except Exception as e:
             show_error(f"An error occurred:", {e})  #TODO: Handle by the argparser not a try/except
 

--- a/src/pieces/commands/cli_loop.py
+++ b/src/pieces/commands/cli_loop.py
@@ -94,6 +94,7 @@ def loop(**kwargs):
                 print(f"Did you mean {most_similar_command}")
         except KeyboardInterrupt:
             print("\nKeyboardInterrupt caught. Returning to the main loop.")
+            print("to exit the terminal use : exit")
             continue
         except Exception as e:
             show_error(f"An error occurred:", {e})  #TODO: Handle by the argparser not a try/except


### PR DESCRIPTION
fixes : #136 
Issue:
When attempting to interrupt the program using Ctrl + C, the system raised a KeyboardInterrupt exception. This caused the program to freeze, requiring the user to kill the terminal session to regain control.

Solution:
I have added an exception handling mechanism for KeyboardInterrupt to prevent the program from freezing. This allows the program to continue running smoothly without needing to kill the terminal.

User Guidance:
To exit the program gracefully, users should follow the provided instructions instead of using Ctrl + C. Here is the suggested command for exiting the program:

To exit the loop gracefully, please type exit 
Avoid using Ctrl + C as it is now handled to maintain the program's stability and avoid freezing.