### PR TITLE
feat(cli): add 'clear' command to clear the terminal and stay in loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@
 
 ## March 25th,2024
 
-- add new cmd for  CLI
+- add new cmd clear cmd for  CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 - Fix some bugs
 - Add edit --classifcation  to reclassify an asset
 - Add the save asset command
+
+## March 25th,2024
+
+- add new cmd for  CLI

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ This will delete an opened asset by using list or search first. If you do not ha
 ```bash
 pieces delete
 ```
+##### clear:
+
+this will clear the terminal and you will stay in the cmd loop and give you clean terminal interface. 
+
+```bash
+pieces clear
+```
 
 #### Search and Query
 ##### Perform a fuzzy search:

--- a/src/pieces/commands/cli_loop.py
+++ b/src/pieces/commands/cli_loop.py
@@ -94,6 +94,7 @@ def loop(**kwargs):
                 print(f"Did you mean {most_similar_command}")
         except KeyboardInterrupt:
             print("\nKeyboardInterrupt caught. Returning to the main loop.")
+            print("to exit the terminal use : exit")
             continue
         except Exception as e:
             show_error(f"An error occurred:", {e})  #TODO: Handle by the argparser not a try/except

--- a/src/pieces/commands/cli_loop.py
+++ b/src/pieces/commands/cli_loop.py
@@ -3,7 +3,7 @@ import platform
 import shlex
 from prompt_toolkit import PromptSession
 from rich.console import Console
-
+import os
 from pieces import __version__
 from pieces.gui import *
 from pieces.pieces_argparser import PiecesArgparser
@@ -51,7 +51,10 @@ def loop(**kwargs):
                 command_args = command_parts[1:]  # Keep the arguments in their original case
             else:
                 continue  # Skip if the input is empty
-
+            
+            if user_input.lower() == 'clear':  # this method is used for clear a terminal 
+                clear_screen()
+                continue
             if user_input == 'exit':
                 double_space("Exiting...")
                 ask_websocket.close_websocket_connection()  # Close using the ask_websocket instance
@@ -99,3 +102,9 @@ def loop(**kwargs):
         except Exception as e:
             show_error(f"An error occurred:", {e})  #TODO: Handle by the argparser not a try/except
 
+
+def clear_screen(): # clear terminal method
+    if os.name == 'nt': # for window
+        os.system('cls')
+    else:               # for other os 
+        os.system('clear')

--- a/src/pieces/gui.py
+++ b/src/pieces/gui.py
@@ -98,6 +98,7 @@ def print_help():
     print("  edit            - Edit the current asset name or classification you can use -n and -c for name and classification respectively")
     print("  delete          - Deletes the current or most recent asset.")
     print("  create          - Creates a new asset based on what you've copied to your clipboard")
+    print("  clear           - to clear the terminal")
     print()
     print("  change_model x  - Change the model that is used in the ask command defaults to chatGPT 3.5 similar to list models")
     print("  ask \"ask\"       - Asks a single question to the model selected in change model. Default timeout set to 10 seconds")


### PR DESCRIPTION
fixes #139 
- Implemented a 'clear' command in the CLI to clear the terminal screen.
- The clear screen functionality is supported for both Windows ('cls') and Unix-based systems ('clear').
- The program remains in the command loop after clearing the screen, allowing continuous use until 'exit' is entered.



https://github.com/pieces-app/cli-agent/assets/107706485/55258614-c386-4152-bd00-9bd8dd85d033



