### PR TITLE
Implement SelectCommand with interactive menu for assets, apps, and models #133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## July 24th, 2024
+
+- Add select menu for the list command
+  
 ## April 8th, 2024
 
 - Add the conversation command with the --rename ,--new , --delete flags

--- a/src/pieces/assets/assets_command.py
+++ b/src/pieces/assets/assets_command.py
@@ -3,7 +3,7 @@ import pyperclip
 
 from pieces.utils import get_file_extension,sanitize_filename,export_code_to_file
 from .assets_api import AssetsCommandsApi
-from pieces.gui import show_error,print_model_details,space_below,double_line
+from pieces.gui import show_error,print_model_details,space_below,double_line,deprecated
 from pieces.settings import Settings
 
 
@@ -39,6 +39,7 @@ class AssetsCommands:
 
 	@classmethod
 	@check_assets_existence
+	@deprecated("open","list assets")
 	def open_asset(cls,**kwargs):
 		item_index = kwargs.get('ITEM_INDEX',1)
 		if not item_index:

--- a/src/pieces/commands/change_model.py
+++ b/src/pieces/commands/change_model.py
@@ -1,7 +1,7 @@
 from pieces.gui import *
 from pieces.settings import Settings
 
-
+@deprecated("change_model","list models")
 def change_model(**kwargs): # Change the model used in the ask command
     model_index = kwargs.get('MODEL_INDEX')
     try:

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -44,6 +44,7 @@ class PiecesSelectMenu:
 
         @bindings.add('enter')
         def select_option(event):
+            event.app.exit()
             args = self.menu_options[self.current_selection][1]
             if isinstance(args,list):
                 self.on_enter_callback(*args)
@@ -51,7 +52,6 @@ class PiecesSelectMenu:
                 self.on_enter_callback(args)
             elif isinstance(args,dict):
                 self.on_enter_callback(**args)
-            event.app.exit()
 
         menu_control = FormattedTextControl(text=self.get_menu_text)
         self.menu_window = Window(content=menu_control, always_hide_cursor=True)

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -9,7 +9,8 @@ from prompt_toolkit.layout.containers import HSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
 from typing import List, Tuple
-from pieces.assets.assets_command import AssetsCommands  # Import AssetsCommands
+from pieces.assets.assets_command import AssetsCommands
+from change_model import change_model
 
 class PiecesSelectMenu:
     def __init__(self, menu_options: List[Tuple]):
@@ -100,7 +101,15 @@ class ListCommand:
 
     @classmethod
     def list_models(cls):
-        models = [(f"{idx}: {model_name}", model_name) for idx, model_name in enumerate(Settings.models, start=1)]
+        # Ensure models are loaded
+        if not hasattr(Settings, 'models'):
+            Settings.load_models()
+        
+        if not Settings.models:
+            print("No models available.")
+            return
+
+        models = [(f"{idx}: {model_name}", model_name) for idx, model_name in enumerate(Settings.models.keys(), start=1)]
         models.append((f"Currently using: {Settings.model_name} with uuid {Settings.model_id}", Settings.model_id))
 
         select_menu = PiecesSelectMenu(models)
@@ -109,6 +118,9 @@ class ListCommand:
         if selected_index is not None:
             cls.selected_item = models[selected_index][1]
             print(f"\nSelected model: {models[selected_index][0]}")
+            
+            # Call change_model function with the selected model index
+            change_model(MODEL_INDEX=selected_index + 1)  # Add 1 because indexing starts from 1 in change_model
         else:
             print("No model selected.")
 

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -15,7 +15,7 @@ class PiecesSelectMenu:
         self.menu_options = menu_options
         self.current_selection = 0
         self.selected_index = None
-    
+
     def get_menu_text(self):
         result = []
         for i, option in enumerate(self.menu_options):
@@ -57,7 +57,6 @@ class PiecesSelectMenu:
 
         return self.selected_index
 
-
 class ListCommand:
     selected_item = None
 
@@ -75,7 +74,27 @@ class ListCommand:
             cls.select_apps()
         elif type == "models":
             cls.select_models()
-    
+
+    @classmethod
+    @check_assets_existence
+    def select_assets(cls, max_assets: int = 10):
+        assets_snapshot = AssetsCommandsApi().assets_snapshot
+        assets = []
+        for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets]):
+            asset = assets_snapshot[uuid]
+            if not asset:
+                asset = AssetsCommandsApi.get_asset_snapshot(uuid)
+            assets.append((f"{asset.name}", uuid))
+
+        select_menu = PiecesSelectMenu(assets)
+        selected_index = select_menu.run()
+        
+        if selected_index is not None:
+            cls.selected_item = assets[selected_index][1]  # Store the UUID of the selected asset
+            print(f"Selected asset: {assets[selected_index][0]}")
+        else:
+            print("No asset selected.")
+
     @classmethod
     def select_models(cls):
         models = [(model_name, model_name) for model_name in Settings.models]
@@ -113,23 +132,3 @@ class ListCommand:
                 print("No app selected.")
         else:
             print("Error: The 'Applications' object does not contain an iterable list of applications.")
-    
-    @classmethod
-    @check_assets_existence
-    def select_assets(cls, max_assets: int = 10):
-        assets_snapshot = AssetsCommandsApi().assets_snapshot
-        assets = []
-        for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets]):
-            asset = assets_snapshot[uuid]
-            if not asset:
-                asset = AssetsCommandsApi.get_asset_snapshot(uuid)
-            assets.append((f"{asset.name}", uuid))
-
-        select_menu = PiecesSelectMenu(assets)
-        selected_index = select_menu.run()
-        
-        if selected_index is not None:
-            cls.selected_item = assets[selected_index][1]  # Store the UUID of the selected asset
-            print(f"Selected asset: {assets[selected_index][0]}")
-        else:
-            print("No asset selected.")

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -59,20 +59,22 @@ class PiecesSelectMenu:
 
 
 class ListCommand:
+    selected_item = None
+
     @classmethod
-    def list_command(cls,**kwargs):
-        type = kwargs.get("type","assets")
-        max_assets = kwargs.get("max_assets",10)
+    def select_command(cls, **kwargs):
+        type = kwargs.get("type", "assets")
+        max_assets = kwargs.get("max_assets", 10)
         if max_assets < 1:
             print("Max assets must be greater than 0")
             max_assets = 10
         
         if type == "assets":
-            cls.list_assets(max_assets)
+            cls.select_assets(max_assets)
         elif type == "apps":
-           cls.list_apps()
+            cls.select_apps()
         elif type == "models":
-            cls.list_models()
+            cls.select_models()
     @staticmethod
     def list_models():
         for idx,model_name in enumerate(Settings.models,start=1):

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -57,11 +57,11 @@ class PiecesSelectMenu:
 
         return self.selected_index
 
-class SelectCommand:
+class ListCommand:
     selected_item = None
 
     @classmethod
-    def select_command(cls, **kwargs):
+    def list_command(cls, **kwargs):
         type = kwargs.get("type", "assets")
         max_assets = kwargs.get("max_assets", 10)
         if max_assets < 1:
@@ -69,15 +69,15 @@ class SelectCommand:
             max_assets = 10
         
         if type == "assets":
-            cls.select_assets(max_assets)
+            cls.list_assets(max_assets)
         elif type == "apps":
-            cls.select_apps()
+            cls.list_apps()
         elif type == "models":
-            cls.select_models()
+            cls.list_models()
 
     @classmethod
     @check_assets_existence
-    def select_assets(cls, max_assets: int = 10):
+    def list_assets(cls, max_assets: int = 10):
         assets_snapshot = AssetsCommandsApi().assets_snapshot
         assets = []
         for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets]):
@@ -96,7 +96,7 @@ class SelectCommand:
             print("No asset selected.")
 
     @classmethod
-    def select_models(cls):
+    def list_models(cls):
         models = [(model_name, model_name) for model_name in Settings.models]
         models.append((f"Currently using: {Settings.model_name} with uuid {Settings.model_id}", Settings.model_id))
 
@@ -110,7 +110,7 @@ class SelectCommand:
             print("No model selected.")
 
     @classmethod
-    def select_apps(cls):
+    def list_apps(cls):
         applications_api = ApplicationsApi(Settings.api_client)
         application_list = applications_api.applications_snapshot()
 

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -25,6 +25,38 @@ class PiecesSelectMenu:
                 result.append(('class:unselected', f'  {option[0]}\n'))
         return result
 
+    def run(self):
+        bindings = KeyBindings()
+
+        @bindings.add('up')
+        def move_up(event):
+            if self.current_selection > 0:
+                self.current_selection -= 1
+            event.app.layout.focus(self.menu_window)
+
+        @bindings.add('down')
+        def move_down(event):
+            if self.current_selection < len(self.menu_options) - 1:
+                self.current_selection += 1
+            event.app.layout.focus(self.menu_window)
+
+        @bindings.add('enter')
+        def select_option(event):
+            self.selected_index = self.current_selection
+            event.app.exit()
+
+        menu_control = FormattedTextControl(text=self.get_menu_text)
+        self.menu_window = Window(content=menu_control, always_hide_cursor=True)
+        layout = Layout(HSplit([self.menu_window]))
+        style = Style.from_dict({
+            'selected': 'reverse',
+            'unselected': ''
+        })
+        app = Application(layout=layout, key_bindings=bindings, style=style, full_screen=True)
+        app.run()
+
+        return self.selected_index
+
 
 class ListCommand:
     @classmethod

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -114,12 +114,22 @@ class ListCommand:
         else:
             print("Error: The 'Applications' object does not contain an iterable list of applications.")
     
-    @staticmethod
+    @classmethod
     @check_assets_existence
-    def list_assets(max_assets:int=10):
+    def select_assets(cls, max_assets: int = 10):
         assets_snapshot = AssetsCommandsApi().assets_snapshot
-        for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets], start=1):
+        assets = []
+        for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets]):
             asset = assets_snapshot[uuid]
             if not asset:
                 asset = AssetsCommandsApi.get_asset_snapshot(uuid)
-            print(f"{i}: {asset.name}")
+            assets.append((f"{asset.name}", uuid))
+
+        select_menu = PiecesSelectMenu(assets)
+        selected_index = select_menu.run()
+        
+        if selected_index is not None:
+            cls.selected_item = assets[selected_index][1]  # Store the UUID of the selected asset
+            print(f"Selected asset: {assets[selected_index][0]}")
+        else:
+            print("No asset selected.")

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -80,11 +80,11 @@ class ListCommand:
     def list_assets(cls, max_assets: int = 10):
         assets_snapshot = AssetsCommandsApi().assets_snapshot
         assets = []
-        for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets]):
+        for i, uuid in enumerate(list(assets_snapshot.keys())[:max_assets], start=1):
             asset = assets_snapshot[uuid]
             if not asset:
                 asset = AssetsCommandsApi.get_asset_snapshot(uuid)
-            assets.append((f"{asset.name}", uuid))
+            assets.append((f"{i}: {asset.name}", uuid))
 
         select_menu = PiecesSelectMenu(assets)
         selected_index = select_menu.run()
@@ -97,7 +97,7 @@ class ListCommand:
 
     @classmethod
     def list_models(cls):
-        models = [(model_name, model_name) for model_name in Settings.models]
+        models = [(f"{idx}: {model_name}", model_name) for idx, model_name in enumerate(Settings.models, start=1)]
         models.append((f"Currently using: {Settings.model_name} with uuid {Settings.model_id}", Settings.model_id))
 
         select_menu = PiecesSelectMenu(models)
@@ -115,20 +115,10 @@ class ListCommand:
         application_list = applications_api.applications_snapshot()
 
         if hasattr(application_list, 'iterable') and isinstance(application_list.iterable, Iterable):
-            apps = []
-            for app in application_list.iterable:
+            for i, app in enumerate(application_list.iterable, start=1):
                 app_name = getattr(app, 'name', 'Unknown').value if hasattr(app, 'name') and hasattr(app.name, 'value') else 'Unknown'
                 app_version = getattr(app, 'version', 'Unknown')
                 app_platform = getattr(app, 'platform', 'Unknown').value if hasattr(app, 'platform') and hasattr(app.platform, 'value') else 'Unknown'
-                apps.append((f"{app_name}, {app_version}, {app_platform}", app))
-
-            select_menu = PiecesSelectMenu(apps)
-            selected_index = select_menu.run()
-
-            if selected_index is not None:
-                cls.selected_item = apps[selected_index][1]
-                print(f"\nSelected app: {apps[selected_index][0]}")
-            else:
-                print("No app selected.")
+                print(f"{i}: {app_name}, {app_version}, {app_platform}")
         else:
             print("Error: The 'Applications' object does not contain an iterable list of applications.")

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -90,28 +90,28 @@ class ListCommand:
         else:
             print("No model selected.")
 
-    @staticmethod
-    def list_apps():
-        # Get the list of applications
-        
+    @classmethod
+    def select_apps(cls):
         applications_api = ApplicationsApi(Settings.api_client)
-
         application_list = applications_api.applications_snapshot()
-        # Check if the application_list object has an iterable attribute and if it is an instance of Iterable
+
         if hasattr(application_list, 'iterable') and isinstance(application_list.iterable, Iterable):
-            # Iterate over the applications in the list
-            for i, app in enumerate(application_list.iterable, start=1):
-                # Get the name of the application, default to 'Unknown' if not available
+            apps = []
+            for app in application_list.iterable:
                 app_name = getattr(app, 'name', 'Unknown').value if hasattr(app, 'name') and hasattr(app.name, 'value') else 'Unknown'
-                # Get the version of the application, default to 'Unknown' if not available
                 app_version = getattr(app, 'version', 'Unknown')
-                # Get the platform of the application, default to 'Unknown' if not available
                 app_platform = getattr(app, 'platform', 'Unknown').value if hasattr(app, 'platform') and hasattr(app.platform, 'value') else 'Unknown'
-                    
-                # Print the application details
-                print(f"{i}: {app_name}, {app_version}, {app_platform}")
+                apps.append((f"{app_name}, {app_version}, {app_platform}", app))
+
+            select_menu = PiecesSelectMenu(apps)
+            selected_index = select_menu.run()
+
+            if selected_index is not None:
+                cls.selected_item = apps[selected_index][1]
+                print(f"\nSelected app: {apps[selected_index][0]}")
+            else:
+                print("No app selected.")
         else:
-            # Print an error message if the 'Applications' object does not contain an iterable list of applications
             print("Error: The 'Applications' object does not contain an iterable list of applications.")
     
     @staticmethod

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -75,11 +75,20 @@ class ListCommand:
             cls.select_apps()
         elif type == "models":
             cls.select_models()
-    @staticmethod
-    def list_models():
-        for idx,model_name in enumerate(Settings.models,start=1):
-            print(f"{idx}: {model_name}")
-        print(f"Currently using: {Settings.model_name} with uuid {Settings.model_id}")
+    
+    @classmethod
+    def select_models(cls):
+        models = [(model_name, model_name) for model_name in Settings.models]
+        models.append((f"Currently using: {Settings.model_name} with uuid {Settings.model_id}", Settings.model_id))
+
+        select_menu = PiecesSelectMenu(models)
+        selected_index = select_menu.run()
+
+        if selected_index is not None:
+            cls.selected_item = models[selected_index][1]
+            print(f"\nSelected model: {models[selected_index][0]}")
+        else:
+            print("No model selected.")
 
     @staticmethod
     def list_apps():

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -1,8 +1,14 @@
 from pieces.settings import Settings
 from collections.abc import Iterable
-from pieces.assets import check_assets_existence,AssetsCommandsApi
-
+from pieces.assets import check_assets_existence, AssetsCommandsApi
 from pieces_os_client.api.applications_api import ApplicationsApi
+from prompt_toolkit import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import HSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.styles import Style
+from typing import List, Tuple
 
 
 class ListCommand:

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -10,6 +10,7 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
 from typing import List, Tuple, Callable
 from pieces.assets.assets_command import AssetsCommands
+import time
 from .change_model import change_model
 
 class PiecesSelectMenu:
@@ -44,14 +45,8 @@ class PiecesSelectMenu:
 
         @bindings.add('enter')
         def select_option(event):
-            event.app.exit()
             args = self.menu_options[self.current_selection][1]
-            if isinstance(args,list):
-                self.on_enter_callback(*args)
-            elif isinstance(args,str):
-                self.on_enter_callback(args)
-            elif isinstance(args,dict):
-                self.on_enter_callback(**args)
+            event.app.exit(result=args)
 
         menu_control = FormattedTextControl(text=self.get_menu_text)
         self.menu_window = Window(content=menu_control, always_hide_cursor=True)
@@ -64,7 +59,14 @@ class PiecesSelectMenu:
         })
 
         app = Application(layout=layout, key_bindings=bindings, style=style, full_screen=True)
-        app.run()
+        args = app.run()
+
+        if isinstance(args, list):
+            self.on_enter_callback(*args)
+        elif isinstance(args, str):
+            self.on_enter_callback(args)
+        elif isinstance(args, dict):
+            self.on_enter_callback(**args)
 
 class ListCommand:
     @classmethod

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -10,6 +10,12 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
 from typing import List, Tuple
 
+class PiecesSelectMenu:
+    def __init__(self, menu_options: List[Tuple]):
+        self.menu_options = menu_options
+        self.current_selection = 0
+        self.selected_index = None
+
 
 class ListCommand:
     @classmethod

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -9,6 +9,7 @@ from prompt_toolkit.layout.containers import HSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
 from typing import List, Tuple
+from pieces.assets.assets_command import AssetsCommands  # Import AssetsCommands
 
 class PiecesSelectMenu:
     def __init__(self, menu_options: List[Tuple]):
@@ -92,6 +93,8 @@ class ListCommand:
         if selected_index is not None:
             cls.selected_item = assets[selected_index][1]  # Store the UUID of the selected asset
             print(f"Selected asset: {assets[selected_index][0]}")
+            AssetsCommands.current_asset = cls.selected_item
+            AssetsCommands.open_asset()  # Call open_asset from AssetsCommands without arguments
         else:
             print("No asset selected.")
 

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -57,7 +57,7 @@ class PiecesSelectMenu:
 
         return self.selected_index
 
-class ListCommand:
+class SelectCommand:
     selected_item = None
 
     @classmethod

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -15,6 +15,15 @@ class PiecesSelectMenu:
         self.menu_options = menu_options
         self.current_selection = 0
         self.selected_index = None
+    
+    def get_menu_text(self):
+        result = []
+        for i, option in enumerate(self.menu_options):
+            if i == self.current_selection:
+                result.append(('class:selected', f'> {option[0]}\n'))
+            else:
+                result.append(('class:unselected', f'  {option[0]}\n'))
+        return result
 
 
 class ListCommand:

--- a/src/pieces/commands/list_command.py
+++ b/src/pieces/commands/list_command.py
@@ -10,7 +10,7 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
 from typing import List, Tuple, Callable
 from pieces.assets.assets_command import AssetsCommands
-from change_model import change_model
+from .change_model import change_model
 
 class PiecesSelectMenu:
     def __init__(self, menu_options:List[Tuple],on_enter_callback:Callable):

--- a/src/pieces/gui.py
+++ b/src/pieces/gui.py
@@ -160,4 +160,15 @@ def show_error(error_message,error):
     print(f"\033[31m{error_message}\033[0m")
     print(f"\033[31m{error}\033[0m")
     print()
-    
+
+def deprecated(command,instead):
+    """
+    Decorator
+        command(str): which is the command that is deprated
+        instead(str): which command should we use instead
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            if kwargs.get("show_warning",True):
+                print(f"'\033[93m' WARNING: `{command}` is deprecated and will be removed in later versions\nPlease use `{instead}` instead \033[0m")
+            func(*args,**kwargs)

--- a/src/pieces/gui.py
+++ b/src/pieces/gui.py
@@ -170,5 +170,7 @@ def deprecated(command,instead):
     def decorator(func):
         def wrapper(*args, **kwargs):
             if kwargs.get("show_warning",True):
-                print(f"'\033[93m' WARNING: `{command}` is deprecated and will be removed in later versions\nPlease use `{instead}` instead \033[0m")
+                print(f"\033[93m WARNING: `{command}` is deprecated and will be removed in later versions\nPlease use `{instead}` instead \033[0m")
             func(*args,**kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Description
This PR introduces a major refactor, renaming ListCommand to SelectCommand and implementing an interactive selection menu for assets, apps, and models. This change enhances user interaction and provides a more intuitive interface for item selection.

## Changes
1. Renamed ListCommand to SelectCommand
   - Better reflects the class's primary function of selecting items

2. Introduced PiecesSelectMenu class
   - Handles interactive menu selection using prompt_toolkit

3. Refactored command methods:
   - list_command → select_command
   - list_assets → select_assets
   - list_apps → select_apps
   - list_models → select_models


## Motivation
The transition from listing to selecting items necessitated a rename of the main class. This change, along with the new interactive selection mechanism, provides a more intuitive and user-friendly interface. It allows for immediate action on selected items, enhancing the overall functionality and user experience of the tool.

## How to Test
To test the code code you can run the following commands :
1. Activate python console by running command : `python`
2. Next, run the following code to see the outputs : 
`from list_command import SelectCommand`
`SelectCommand.select_command(type="assets", max_assets=5)`


running the following code should help you see your selection menu . replace the type parameters with "apps" or "models" according to your need and requirement .
