### PR TITLE
Refactor AssetsIdentifiersWS to use BaseWebsocket #157

### DIFF
--- a/src/pieces/assets/assets_identifiers_ws.py
+++ b/src/pieces/assets/assets_identifiers_ws.py
@@ -104,4 +104,3 @@ class AssetsIdentifiersWS(BaseWebsocket):
     def close_all(cls):
         """Close all websocket connections."""
         super().close_all()
-

--- a/src/pieces/assets/assets_identifiers_ws.py
+++ b/src/pieces/assets/assets_identifiers_ws.py
@@ -5,7 +5,67 @@ from pieces.settings import Settings
 import threading
 from abc import ABC, abstractmethod
 
+class BaseWebsocket(ABC):
+    instances = []
 
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(BaseWebsocket, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(self, on_message_callback):
+        self.ws = None
+        self.on_message_callback = on_message_callback
+        self.loop = asyncio.new_event_loop()
+        self.thread = None
+        if self not in BaseWebsocket.instances:
+            BaseWebsocket.instances.append(self)
+
+    @abstractmethod
+    def get_url(self):
+        pass
+
+    @abstractmethod
+    def on_message(self, ws, message):
+        pass
+
+    def on_error(self, ws, error):
+        print(f"Error: {error}")
+        self.ws = None
+
+    def on_close(self, ws, close_status_code, close_msg):
+        print(f"WebSocket closed: {close_status_code} - {close_msg}")
+        self.ws = None
+
+    def on_open(self, ws):
+        print("WebSocket connection opened")
+
+    def open_websocket(self):
+        if self.ws:
+            return
+        self.ws = websocket.WebSocketApp(
+            self.get_url(),
+            on_message=self.on_message,
+            on_error=self.on_error,
+            on_close=self.on_close,
+            on_open=self.on_open
+        )
+        self.ws.run_forever()
+
+    def start(self):
+        self.thread = threading.Thread(target=self.open_websocket)
+        self.thread.start()
+
+    def close_websocket_connection(self):
+        if self.ws:
+            self.ws.close()
+        if self.thread:
+            self.thread.join()
+
+    @classmethod
+    def close_all(cls):
+        for instance in cls.instances:
+            instance.close_websocket_connection()
 
 class AssetsIdentifiersWS:
     def __new__(cls,*args,**kwargs):

--- a/src/pieces/assets/assets_identifiers_ws.py
+++ b/src/pieces/assets/assets_identifiers_ws.py
@@ -3,6 +3,8 @@ import pieces_os_client as pos_client
 import websocket
 from pieces.settings import Settings
 import threading
+from abc import ABC, abstractmethod
+
 
 
 class AssetsIdentifiersWS:

--- a/src/pieces/assets/assets_identifiers_ws.py
+++ b/src/pieces/assets/assets_identifiers_ws.py
@@ -67,34 +67,13 @@ class BaseWebsocket(ABC):
         for instance in cls.instances:
             instance.close_websocket_connection()
 
-class AssetsIdentifiersWS:
-    def __new__(cls,*args,**kwargs):
-        if not hasattr(cls, 'instance'):
-            cls.instance = super(AssetsIdentifiersWS, cls).__new__(cls)
-        return cls.instance
-    
+class AssetsIdentifiersWS(BaseWebsocket):
     def __init__(self, on_message_callback):
-        self.ws = None
-        self.on_message_callback = on_message_callback
+        super().__init__(on_message_callback)
+        self.start()  # Using the start method from BaseWebsocket
 
-        # Create a new event loop
-        self.loop = asyncio.new_event_loop()
-
-        # Run the event loop in a new thread
-        self.thread = threading.Thread(target=self.open_websocket)
-        self.thread.start()
-    
-
-    def open_websocket(self):
-        """Opens a websocket connection"""
-        if self.ws: # connect only once
-            return
-        self.ws = websocket.WebSocketApp(Settings.ASSETS_IDENTIFIERS_WS_URL,
-                                         on_message=self.on_message,
-                                         on_error=self.on_error,
-                                         on_close=self.on_close)
-        self.ws.on_open = self.on_open
-        self.ws.run_forever()
+    def get_url(self):
+        return Settings.ASSETS_IDENTIFIERS_WS_URL
 
     def on_message(self, ws, message):
         """Handle incoming websocket messages."""
@@ -102,18 +81,27 @@ class AssetsIdentifiersWS:
 
     def on_error(self, ws, error):
         """Handle websocket errors."""
-        self.ws = None
+        super().on_error(ws, error)
         print(error)
 
     def on_close(self, ws, close_status_code, close_msg):
         """Handle websocket closure."""
-        self.ws = None
+        super().on_close(ws, close_status_code, close_msg)
 
     def on_open(self, ws):
         """Handle websocket opening."""
-        pass
+        super().on_open(ws)
+
+    def open_websocket(self):
+        """Opens a websocket connection"""
+        super().open_websocket()
 
     def close_websocket_connection(self):
         """Close the websocket connection."""
-        if self.ws:
-            self.ws.close()
+        super().close_websocket_connection()
+
+    @classmethod
+    def close_all(cls):
+        """Close all websocket connections."""
+        super().close_all()
+


### PR DESCRIPTION
## Description
This PR refactors the `AssetsIdentifiersWS` class to inherit from a new `BaseWebsocket` class. This change improves code reusability, consistency, and maintainability across our websocket implementations. this Pr is expected to address the issue #157 .
## Changes
- Introduced a new abstract `BaseWebsocket` class with common websocket functionality
- Refactored `AssetsIdentifiersWS` to inherit from `BaseWebsocket`
- Implemented abstract methods and overrode necessary methods in `AssetsIdentifiersWS`
- Utilized `BaseWebsocket` methods in `AssetsIdentifiersWS` where appropriate
- Updated the websocket creation process to use the new class structure

## Benefits
- Improved code reusability across different websocket implementations
- Enhanced consistency in websocket handling
- Easier maintenance and future extensions of websocket functionality
- Singleton pattern now handled in the base class

## Notes
- This change maintains backwards compatibility with the existing `AssetsIdentifiersWS` usage
- Future websocket implementations should now inherit from `BaseWebsocket`