### PR TITLE
fix the list menu color on light mode terminals

### DIFF
--- a/src/pieces/utils.py
+++ b/src/pieces/utils.py
@@ -168,9 +168,9 @@ class PiecesSelectMenu:
 
         style = Style.from_dict(
             {
-                "selected": "#ffffff bold",
-                "title": "#aaddff bold",
-                "footer": "#888888 italic",
+                "selected": "reverse bold",
+                "title": "ansicyan bold",
+                "footer": "ansibrightblack italic",
             }
         )
 


### PR DESCRIPTION
Before
<img width="1506" alt="Screenshot 2025-07-01 at 2 35 28 AM" src="https://github.com/user-attachments/assets/ab0c78a1-5c0f-4b0a-a2a6-7df4902b5df2" />
After
<img width="1500" alt="Screenshot 2025-07-01 at 2 35 00 AM" src="https://github.com/user-attachments/assets/a53ba46d-0318-4765-a318-3baa6a19033b" />
