### PR TITLE
fix sentry adding useless errors

### DIFF
--- a/src/pieces/core/cli_loop.py
+++ b/src/pieces/core/cli_loop.py
@@ -142,7 +142,9 @@ def run_command(user_input: str, command_name: str, command_args: List[str]) -> 
     except SystemExit as e:
         # argparse calls sys.exit on error - catch and handle gracefully
         # Settings.logger.print(f"Invalid arguments for command: {command_name}")
-        Settings.logger.error(f"Invalid arguments for command: {command_name}, {e}")
+        Settings.logger.error(
+            f"Invalid arguments for command: {command_name}, {e}", ignore_sentry=True
+        )
     except Exception as e:
         Settings.logger.error(f"Error executing {command_name}: {str(e)}")
         Settings.show_error(f"Command failed: {command_name}", str(e))


### PR DESCRIPTION
https://pieces.sentry.io/issues/6819818468/?environment=staging&project=4509837316980737&query=is%3Aunresolved&referrer=issue-stream
https://pieces.sentry.io/issues/6819814331/?environment=staging&project=4509837316980737&query=is%3Aunresolved&referrer=issue-stream
noticed those should not be logged those are exit exceptions and should not be logged to sentry