### PR TITLE
feat: Implement 4-step validation with authentication check

### DIFF
--- a/src/pieces/_vendor/pieces_os_client/wrapper/websockets/auth_ws.py
+++ b/src/pieces/_vendor/pieces_os_client/wrapper/websockets/auth_ws.py
@@ -59,6 +59,8 @@ class AuthWS(BaseWebsocket):
 			json.decoder.JSONDecodeError: If the message cannot be decoded as JSON.
 		"""
 		try:
-			self.on_message_callback(UserProfile.from_json(message))
+			user = UserProfile.from_json(message)
 		except json.decoder.JSONDecodeError:
-			self.on_message_callback(None)  # User logged out!
+			user = None # User logged out!
+		self.on_message_callback(user) 
+		self.pieces_client.user.user_profile = user

--- a/src/pieces/app.py
+++ b/src/pieces/app.py
@@ -120,7 +120,9 @@ class PiecesCLI:
             "config",
             "completion",
         ] and not (command == "mcp" and mcp_subcommand == "start"):
-            bypass_login = True if (command in ["version"]) else False
+            bypass_login = (
+                True if (command in ["version", "logout", "login"]) else False
+            )
             Settings.startup(bypass_login)
         Settings.logger.debug(f"Running command {command} using: {args}")
         args.func(**vars(args))

--- a/src/pieces/mcp/gateway.py
+++ b/src/pieces/mcp/gateway.py
@@ -16,6 +16,7 @@ from .._vendor.pieces_os_client.wrapper.version_compatibility import (
 )
 from .._vendor.pieces_os_client.wrapper.websockets.health_ws import HealthWS
 from .._vendor.pieces_os_client.wrapper.websockets.ltm_vision_ws import LTMVisionWS
+from .._vendor.pieces_os_client.wrapper.websockets.auth_ws import AuthWS
 from mcp.client.sse import sse_client
 from mcp import ClientSession
 from mcp.server import Server
@@ -163,6 +164,11 @@ class PosMcpConnection:
 
                 os_id = Settings.get_os_id()
                 sentry_sdk.set_extra("os_id", os_id or "unknown")
+
+                # Update the user profile cache
+                Settings.pieces_client.user.user_profile = (
+                    Settings.pieces_client.user_api.user_snapshot().user
+                )
                 # Update LTM status cache
                 Settings.pieces_client.copilot.context.ltm.ltm_status = Settings.pieces_client.work_stream_pattern_engine_api.workstream_pattern_engine_processors_vision_status()
                 return True
@@ -176,10 +182,11 @@ class PosMcpConnection:
 
     def _validate_system_status(self, tool_name: str) -> tuple[bool, str]:
         """
-        Perform 3-step validation before executing any command:
+        Perform 4-step validation before executing any command:
         1. Check health WebSocket
         2. Check compatibility
-        3. Check LTM (for LTM tools)
+        3. Check Auth
+        4. Check LTM (for LTM tools)
 
         Returns:
             tuple[bool, str]: (is_valid, error_message)
@@ -197,7 +204,14 @@ class PosMcpConnection:
         if not is_compatible:
             return False, compatibility_message
 
-        # Step 3: Check LTM status (only for LTM-related tools)
+        # Step 3: Check Auth status
+        if not Settings.pieces_client.user.user_profile:
+            return False, (
+                "User must sign up to use this tool, please run:\n\n`pieces login`\n\n"
+                "This will open the authentication page in your browser. After signing in, you can retry your request."
+            )
+
+        # Step 4: Check LTM status (only for LTM-related tools)
         if tool_name in ["ask_pieces_ltm", "create_pieces_memory"]:
             ltm_enabled = self._check_ltm_status()
             if not ltm_enabled:
@@ -667,7 +681,11 @@ async def main():
     if hasattr(signal, "SIGINT"):
         signal.signal(signal.SIGINT, lambda s, f: signal_handler())
 
+    # HealthWS starts the AuthWS, which starts the LTMVisionWS
     ltm_vision = LTMVisionWS(Settings.pieces_client, lambda x: None)
+    user_ws = AuthWS(
+        Settings.pieces_client, lambda x: None, lambda x: ltm_vision.start()
+    )
 
     def on_ws_event(ws, e):
         if isinstance(e, WebSocketConnectionClosedException):
@@ -682,7 +700,7 @@ async def main():
     health_ws = HealthWS(
         Settings.pieces_client,
         lambda x: None,
-        lambda ws: ltm_vision.start(),
+        lambda ws: user_ws.start(),
         on_error=on_ws_event,
     )
 


### PR DESCRIPTION
```
Complete Test Summary
✅ Step 1 Validation (PiecesOS not running):
Killed PiecesOS process with killall "Pieces OS"
MCP returned: "PiecesOS is not running. To use this tool, please run: pieces open"
✅ Step 3 Validation (User not authenticated):
Logged out user with pieces logout
MCP returned: "User must sign up to use this tool, please run: pieces login"
✅ Step 4 Validation (LTM not enabled):
Started PiecesOS without LTM (pieces open)
MCP returned: "PiecesOS is running but Long Term Memory (LTM) is not enabled. To use this tool, please run: pieces open --ltm"
✅ All Steps Pass:
Enabled LTM with pieces open --ltm
Logged in with pieces login
MCP successfully returned memory data
```


cursor tested the MCP for me (it did bunch of combinations of closing pos and using pieces logout)