### PR TITLE
fix(ltm): evaluate BasicRange.create() datetime defaults at call time

### DIFF
--- a/src/pieces/_vendor/pieces_os_client/wrapper/basic_identifier/range.py
+++ b/src/pieces/_vendor/pieces_os_client/wrapper/basic_identifier/range.py
@@ -66,7 +66,7 @@ class BasicRange(Basic):
     @staticmethod
     def create(
         from_: Optional[datetime.datetime] = None,
-        to: Optional[datetime.datetime] = datetime.datetime.now(),
+        to: Optional[datetime.datetime] = None,
     ) -> "BasicRange":
         """
         Creates a new range based on a Range.
@@ -82,6 +82,8 @@ class BasicRange(Basic):
         from pieces._vendor.pieces_os_client.models.grouped_timestamp import GroupedTimestamp
         if not from_:
             from_ = datetime.datetime.now() - datetime.timedelta(minutes=15)
+        if not to:
+            to = datetime.datetime.now()
 
         r = RangeSnapshot.pieces_client.ranges_api.ranges_create_new_range(
             SeededRange(


### PR DESCRIPTION
## Summary

`BasicRange.create()` evaluated `datetime.datetime.now()` as a default argument, so the `to` parameter was frozen at module-import time. `chat_enable_ltm()` calls `BasicRange.create()` with no arguments every time LTM is turned on for a chat, so the resulting temporal range capped at process-start. Long-running CLI/TUI sessions retrieved progressively staler context the longer they stayed open, while the unaffected workstream view kept rendering current data.

This is the classic Python mutable-default-argument anti-pattern, applied to `datetime.now()`.

## Repro

1. Launch `pieces tui`.
2. Wait 15+ minutes.
3. Open a fresh chat, enable LTM, ask about activity captured in the last few minutes.
4. Pre-fix: no recent context returned (the chat's range `to` is pinned at TUI startup).
5. Post-fix: recent context retrieved correctly.

## Fix

Default `to` to `None`, resolve to `now()` inside the body. This mirrors the existing pattern already used for `from_` in this same function.

## Test plan

- [x] Unit syntax / py_compile of the patched file
- [x] Local install on macOS 26.4.1 (Pieces OS 12.3.11, CLI 1.20.1) — newest range `to` value now advances with each call instead of staying pinned at TUI launch time
- [ ] Reviewer confirms the equivalent change is applied (or backported) in pieces-os-client-sdk-for-python — separate PR pending

The vendored copy here at `src/pieces/_vendor/pieces_os_client/wrapper/basic_identifier/range.py` is currently slightly improved over the upstream SDK (only `to` is frozen, vs both args in the SDK), so this PR fixes only that one default.