### PR TITLE
fix(tui): make Ctrl+L and Ctrl+N fire from chat input via priority bindings

### DIFF
--- a/src/pieces/tui/views/copilot_view.py
+++ b/src/pieces/tui/views/copilot_view.py
@@ -24,9 +24,16 @@ class PiecesCopilot(BaseDualPaneView):
     """Copilot/chat interface with consistent dual-pane layout."""
 
     BINDINGS = [
-        Binding("ctrl+n", "new_chat", "New Chat"),
+        # priority=True so these screen-level shortcuts fire even when
+        # the chat input has focus. Without it, common readline/terminal
+        # bindings inside the input (notably Ctrl+L = clear-line and
+        # Ctrl+N = next-line) silently swallow the keypress before it
+        # reaches the screen's action handler — the symptom is the
+        # action only firing after the user opens another modal that
+        # transfers focus away from the input.
+        Binding("ctrl+n", "new_chat", "New Chat", priority=True),
         Binding("ctrl+shift+m", "change_model", "Change Model"),
-        Binding("ctrl+l", "toggle_ltm", "Toggle LTM"),
+        Binding("ctrl+l", "toggle_ltm", "Toggle LTM", priority=True),
         Binding("ctrl+shift+w", "switch_to_workstream", "Switch to Workstream"),
         Binding("ctrl+c", "stop_streaming", "Stop Streaming"),
     ]


### PR DESCRIPTION
## Summary

Screen-level `Binding(...)` declarations are consultative by default — focused widgets get first crack at every keypress and can swallow it. The chat input (a `TextArea` descendant) inherits readline-style bindings that consume **Ctrl+L** (clear-line) and **Ctrl+N** (next-line), so those keypresses never reach `action_toggle_ltm` / `action_new_chat`.

The visible symptom was that pressing Ctrl+L appeared to do nothing until the user opened another modal (e.g. Ctrl+Shift+M model selection) which transferred focus off the input. After that modal closed, focus landed on the screen and Ctrl+L finally bubbled up to the binding.

Adding `priority=True` to both bindings tells Textual to fire the screen action before the focused widget gets to consume the key, so the shortcut works regardless of where focus currently lives.

## Why not all bindings?

Ctrl+Shift+M (change model), Ctrl+Shift+W (workstream), and Ctrl+C (stop streaming) keep their default priority:
- Ctrl+Shift+M and Ctrl+Shift+W are rare enough that no widget binds them.
- Ctrl+C is special-cased in Textual; elevating it could interfere with focus-aware copy/cancel flows.

## Test plan

- [x] Verified Ctrl+L toggles LTM from inside the chat input on a fresh TUI launch (previously only worked after opening model selection).
- [x] Verified Ctrl+N creates a new chat from inside the chat input.
- [x] Other shortcuts unaffected.