### PR TITLE
fix: clarify CLI PiecesOS readiness guidance

### DIFF
--- a/src/pieces/core/install_pieces_os.py
+++ b/src/pieces/core/install_pieces_os.py
@@ -37,7 +37,7 @@ class PiecesInstaller:
                     )
                     if model.state == DownloadState.FAILED:
                         Settings.logger.print(
-                            "❌ Failed to install PiecesOS, Opening in your webbrowser"
+                            "❌ Failed to install PiecesOS automatically. Opening the PiecesOS download page in your browser."
                         )
                         self.download_docs()
                     elif model.state == DownloadState.COMPLETED:

--- a/src/pieces/core/onboarding.py
+++ b/src/pieces/core/onboarding.py
@@ -14,6 +14,7 @@ import sys
 from pieces.core.cli_loop import run_command, extract_text
 from pieces.settings import Settings
 from pieces.urls import URLs
+from pieces.runtime_readiness import print_pieces_os_not_ready
 
 
 def get_prompt():
@@ -266,7 +267,7 @@ def onboarding_command(**kwargs):
     Settings.logger.print("Whenever you want to exit the onboarding flow type `exit`.")
 
     if not Settings.pieces_client.open_pieces_os():
-        Settings.logger.print("❌ PiecesOS is not running")
+        print_pieces_os_not_ready("running onboarding")
         Settings.logger.print(
             Markdown(
                 "**PiecesOS** is a **required** background service"

--- a/src/pieces/core/open_command.py
+++ b/src/pieces/core/open_command.py
@@ -1,6 +1,7 @@
 from pieces.urls import URLs
 from pieces.settings import Settings
 from pieces.copilot.ltm import enable_ltm
+from pieces.runtime_readiness import print_pieces_os_not_ready
 
 def open_command(**kwargs):
     from pieces._vendor.pieces_os_client.models.inactive_os_server_applet import InactiveOSServerApplet
@@ -14,7 +15,7 @@ def open_command(**kwargs):
     health = Settings.pieces_client.open_pieces_os()
 
     if (drive or copilot or settings or ltm) and not health:
-        Settings.logger.print("PiecesOS is not running")
+        print_pieces_os_not_ready("opening a Pieces app")
         return
 
     if ltm and enable_ltm(auto_enable=True):

--- a/src/pieces/runtime_readiness.py
+++ b/src/pieces/runtime_readiness.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def pieces_os_not_ready_lines(context: str | None = None) -> list[str]:
+    if context:
+        headline = f"❌ PiecesOS is not reachable while {context}."
+    else:
+        headline = "❌ PiecesOS is not reachable from Pieces CLI."
+
+    return [
+        headline,
+        "PiecesOS may be uninstalled, not running, still starting, or failing local readiness/port discovery.",
+        "Try:",
+        "  1. Run `pieces install` to install or repair PiecesOS.",
+        "  2. Run `pieces open --pieces_os` or open/restart PiecesOS, then retry.",
+        "  3. If this keeps happening, copy `pieces version` output and share it with support.",
+    ]
+
+
+def print_pieces_os_not_ready(context: str | None = None) -> None:
+    from pieces.settings import Settings
+
+    for line in pieces_os_not_ready_lines(context):
+        Settings.logger.print(line)

--- a/tests/test_runtime_readiness.py
+++ b/tests/test_runtime_readiness.py
@@ -1,0 +1,17 @@
+from pieces.runtime_readiness import pieces_os_not_ready_lines
+
+
+def test_pieces_os_not_ready_lines_include_context_and_next_steps():
+    lines = pieces_os_not_ready_lines("opening a Pieces app")
+    text = "\n".join(lines)
+
+    assert lines[0] == "❌ PiecesOS is not reachable while opening a Pieces app."
+    assert "pieces install" in text
+    assert "pieces open --pieces_os" in text
+    assert "pieces version" in text
+
+
+def test_pieces_os_not_ready_lines_default_context():
+    lines = pieces_os_not_ready_lines()
+
+    assert lines[0] == "❌ PiecesOS is not reachable from Pieces CLI."


### PR DESCRIPTION
What changed:
- Added shared CLI readiness guidance for PiecesOS-not-reachable cases.
- Reused that guidance in onboarding and open command flows instead of generic "PiecesOS is not running" wording.
- Clarified the automatic install fallback message when CLI install cannot complete automatically.
- Added focused unit coverage for the readiness guidance text.

Why:
- This is a low-risk first step toward making install/runtime readiness failures less vague for users and support.
- It does not add a full doctor/reset/auto-heal system yet.
- It keeps the first PR scoped to user-facing guidance while the broader install/readiness support artifact work continues.

Validation:
- PYTHONPATH=src .venv/bin/python -m pytest tests/test_runtime_readiness.py -q
- PYTHONPATH=src .venv/bin/python -m compileall -q src/pieces/runtime_readiness.py src/pieces/core/open_command.py src/pieces/core/onboarding.py src/pieces/core/install_pieces_os.py
- PYTHONPATH=src .venv/bin/python import smoke for readiness/open/onboarding/install modules
- PYTHONPATH=src .venv/bin/pieces --help
- PYTHONPATH=src .venv/bin/pieces install --help
- PYTHONPATH=src .venv/bin/pieces open --help
- PYTHONPATH=src .venv/bin/pieces mcp --help

Not claiming:
- Full CLI pytest suite
- Full PiecesOS install reproduction
- Full doctor/support artifact implementation
- MCP preflight implementation
