### PR TITLE
fix(urls): update Raycast MCP docs URL

### DIFF
--- a/src/pieces/urls.py
+++ b/src/pieces/urls.py
@@ -36,7 +36,7 @@ class URLs(Enum):
         "https://docs.windsurf.com/windsurf/cascade/mcp#model-context-protocol-mcp"
     )
     ZED_MCP_DOCS = "https://zed.dev/docs/ai/mcp"
-    RAYCAST_MCP_DOCS = "https://manual.raycast.com/model-context-protocol"
+    RAYCAST_MCP_DOCS = "https://manual.raycast.com/ai/model-context-protocol"
     WARP_MCP_DOCS = "https://docs.warp.dev/knowledge-and-collaboration/mcp"
     SHORT_WAVE_MCP_DOCS = "https://www.shortwave.com/docs/how-tos/using-mcp/"
     CLAUDE_CLI_MCP_DOCS = "https://docs.anthropic.com/en/docs/claude-code/mcp"


### PR DESCRIPTION
- Raycast moved the MCP docs page under `/ai/model-context-protocol`.
- The old `manual.raycast.com/model-context-protocol` URL now returns 404.
- This updates `RAYCAST_MCP_DOCS`, which is used by `pieces mcp docs --integration raycast`.
- This is a one-line CI/user-facing link fix.
- No test behavior, workflow behavior, MCP handler logic, or readiness wording changes.

Validation:
- old URL returns 404
- new URL returns 200
- targeted `RAYCAST_MCP_DOCS` link test passed
- full `tests/links_test.py` passed: 56 passed, 1 skipped
- `pieces mcp docs --integration raycast` prints the new URL