### PR TITLE
ci: migrate GCP auth to keyless Workload Identity Federation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,6 @@ on:
         required: false
       ssh_private_key:
         required: true
-      credentials_json:
-        required: false
       apple_app_specific_password:
         required: false
       fastlane_password:
@@ -347,6 +345,9 @@ jobs:
     #    if: github.ref == 'refs/heads/main'
     needs:
       - build
+    permissions:
+      id-token: write
+      contents: read
     steps:
       ### Checking out our Repo to get pyproject.toml and other files
       - uses: actions/checkout@v3
@@ -358,12 +359,13 @@ jobs:
       - name: List
         run: ls -la
 
-      ### Authenticating with gcloud
+      ### Authenticating with gcloud via keyless Workload Identity Federation
       - name: Authenticate with Google cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.credentials_json }}
-          project_id: ${{ inputs.project_id }}
+          project_id: integration-server-326115
+          workload_identity_provider: projects/497784144587/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-actions@integration-server-326115.iam.gserviceaccount.com
           create_credentials_file: true
 
       ### Setting up gcloud cli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,6 @@ jobs:
       pypi_token: ${{ secrets.PYPI_TOKEN }}
       pypi_test_token: ${{ secrets.PYPI_TEST_TOKEN }}
       ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-      credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       apple_app_specific_password: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       fastlane_password: ${{ secrets.FASTLANE_PASSWORD }}
       match_password: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    permissions:
+      id-token: write
+      contents: read
     with:
       deploy: true
     secrets:

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -16,7 +16,6 @@ jobs:
       pypi_token: ${{ secrets.PYPI_TOKEN }}
       pypi_test_token: ${{ secrets.PYPI_TEST_TOKEN }}
       ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-      credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       apple_app_specific_password: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       fastlane_password: ${{ secrets.FASTLANE_PASSWORD }}
       match_password: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    permissions:
+      id-token: write
+      contents: read
     with:
       deploy: false
     secrets:


### PR DESCRIPTION
## Summary

Migrates this repo's CI from a **static GCP service-account key** to **keyless Workload Identity Federation (WIF)**, as part of the org-wide incident remediation.

The static key behind the `GCP_CREDENTIALS` secret (SA `github-actions@integration-server-326115.iam.gserviceaccount.com`) was **leaked and deleted**, so the `push-build` job's GCS uploads are currently **broken**. This restores them keylessly.

### What changed
- **`build.yaml` auth step** → `google-github-actions/auth@v3` using `workload_identity_provider` + `service_account` (no `credentials_json`), matching the `builds_server` reference (PRs #19/#20).
- Added `permissions: { id-token: write, contents: read }` to the `push-build` job (required for OIDC token minting).
- **Fixed undeclared `project_id` input bug**: the auth step referenced `${{ inputs.project_id }}`, but `project_id` was never declared as a workflow input (only `deploy` was), so it silently resolved to empty. Now pinned to `integration-server-326115` — the home project of the CI SA and the `app-releases-production` / `app-releases-staging` GCS buckets.
- Removed the now-unused `credentials_json` secret from `build.yaml` and the `GCP_CREDENTIALS` pass-through from `staging.yaml` and `release.yaml`.

### GCP backing changes (already applied)
- Repo-scoped `roles/iam.workloadIdentityUser` binding added on the CI SA for `principalSet://.../attribute.repository/pieces-app/cli-agent` (provider `projects/497784144587/.../github-pool/providers/github-provider`).
- **No runtime SA needed** — CI only does GCS uploads via `gsutil` (no Cloud Run / Artifact Registry / image deploy).

The `GCP_CREDENTIALS` repo secret is intentionally left in place (not deleted) and can be removed once this is verified.

## Test plan
- [ ] Trigger `Staging` (push to `main`/`feat-headless`) and confirm the `push-build` job authenticates via WIF and `gcloud info` shows the impersonated SA.
- [ ] Confirm `gsutil cp` uploads to `gs://app-releases-staging/...` succeed.
- [ ] Cut a tag to exercise `Release` → production bucket uploads.

Made with [Cursor](https://cursor.com)